### PR TITLE
Frontend: hook up auth + dashboard + energy

### DIFF
--- a/frontend/app.py
+++ b/frontend/app.py
@@ -3,4 +3,14 @@ st.set_page_config(page_title="UF MANA", page_icon=":robot_face:", layout="wide"
 
 st.title("UF MANA")
 st.caption("Energy-aware scheduling for students who can't afford burnout")
-st.sidebar.success("Welcome to UF MANA! Please select a page from the sidebar to get started.")
+
+token = st.session_state.get("token")
+user = st.session_state.get("user")
+
+if token:
+    st.sidebar.success(f"Signed in as {user.get('username', user.get('name', 'User'))}")
+    if st.sidebar.button("Logout"):
+        st.session_state.clear()
+        st.rerun()
+else:
+    st.sidebar.success("Welcome to UF MANA! Please sign up or log in from the pages menu.")

--- a/frontend/pages/3_Add_Event.py
+++ b/frontend/pages/3_Add_Event.py
@@ -1,22 +1,39 @@
 import streamlit as st
+from datetime import date, datetime, time
+
 from services.event_service import add_event
-from datetime import date
+
 
 st.title("Add Event")
 
+token = st.session_state.get("token")
+if not token:
+    st.warning("Please sign up / log in first.")
+    st.stop()
+
 title = st.text_input("Event Title")
 event_date = st.date_input("Date", value=date.today())
+event_time = st.time_input("Time", value=time(9, 0))
 energy_cost = st.slider("Energy Cost", 1, 10, 3)
 recurring = st.checkbox("Recurring event?")
 
 if st.button("Add Event"):
-    if title:
-        add_event("u1", {
-            "title": title,
-            "date": str(event_date),
-            "energy_cost": energy_cost,
-            "recurring": recurring
-        })
-        st.success(f"Added: {title}")
-    else:
+    if not title.strip():
         st.warning("Please enter an event title.")
+        st.stop()
+
+    scheduled_dt = datetime.combine(event_date, event_time)
+
+    payload = {
+        "title": title.strip(),
+        "description": "",
+        "scheduled_time": scheduled_dt.isoformat(),
+        "energy_cost": float(energy_cost),
+        "recurring": bool(recurring),  # backend may ignore if not implemented
+    }
+
+    try:
+        add_event(token, payload)
+        st.success(f"Added: {title.strip()}")
+    except Exception as e:
+        st.error(f"Could not add event: {e}")

--- a/frontend/pages/dashboard.py
+++ b/frontend/pages/dashboard.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import requests
+import streamlit as st
+
+from services.auth_service import BACKEND_URL, build_auth_headers
+
+
+st.title("Dashboard Summary")
+
+token = st.session_state.get("token")
+if not token:
+    st.warning("Please sign up / log in first.")
+    st.stop()
+
+try:
+    resp = requests.get(
+        f"{BACKEND_URL}/dashboard/summary",
+        headers=build_auth_headers(token),
+        timeout=20,
+    )
+    data = resp.json()
+except Exception as e:
+    st.error(f"Failed to load dashboard summary: {e}")
+    st.stop()
+
+if resp.status_code >= 400:
+    st.error(data.get("detail") or "Dashboard summary request failed.")
+    st.stop()
+
+remaining_cost = float(data.get("remaining_today_energy_cost", 0.0))
+current_energy = float(data.get("current_energy", 0.0))
+estimated_end = float(data.get("estimated_end_of_day_energy", 0.0))
+
+planned_tasks_count = int(data.get("planned_tasks_count", 0))
+completed_tasks_count = int(data.get("completed_tasks_count", 0))
+remaining_today_tasks_amount = int(data.get("remaining_today_tasks_amount", 0))
+
+st.metric("Current Mana / Energy", f"{current_energy:.1f}")
+st.metric("Planned Energy Cost Today", f"{remaining_cost:.1f}")
+st.metric("Estimated End-of-Day Energy", f"{estimated_end:.1f}")
+
+st.subheader("Task Status")
+col1, col2, col3 = st.columns(3)
+col1.metric("Planned Tasks", planned_tasks_count)
+col2.metric("Completed Tasks", completed_tasks_count)
+col3.metric("Remaining Today", remaining_today_tasks_amount)
+
+# Simple heuristic guidance; actual scheduling intelligence can be improved server-side.
+if estimated_end <= 2.0:
+    st.warning("Your plan may leave you drained. Consider moving one task or adding a recovery break.")
+elif current_energy <= 2.0:
+    st.info("You're starting low. If possible, do a smaller task first, then reassess.")
+else:
+    st.success("Your energy budget looks reasonable. Keep an eye on it as your day changes.")
+

--- a/frontend/pages/log_mana.py
+++ b/frontend/pages/log_mana.py
@@ -1,0 +1,33 @@
+import requests
+import streamlit as st
+
+from services.auth_service import BACKEND_URL, build_auth_headers
+
+
+st.title("Log Mana / Energy")
+
+token = st.session_state.get("token")
+if not token:
+    st.warning("Please sign up / log in first.")
+    st.stop()
+
+energy_level = st.slider("Current energy (mana)", 0.0, 10.0, 7.0, step=0.5)
+
+if st.button("Log Energy"):
+    try:
+        resp = requests.post(
+            f"{BACKEND_URL}/energy/log",
+            json={"energy_level": float(energy_level)},
+            headers=build_auth_headers(token),
+            timeout=20,
+        )
+        data = resp.json()
+    except Exception as e:
+        st.error(f"Failed to log energy: {e}")
+    else:
+        if resp.status_code >= 400:
+            st.error(data.get("detail") or "Energy log failed.")
+        else:
+            st.success("Energy logged.")
+            st.json(data)
+

--- a/frontend/pages/signup.py
+++ b/frontend/pages/signup.py
@@ -1,0 +1,26 @@
+import streamlit as st
+
+from services.auth_service import signup as api_signup
+
+
+st.title("Sign Up")
+
+with st.form("signup_form", clear_on_submit=False):
+    username = st.text_input("Username")
+    password = st.text_input("Password", type="password")
+    submitted = st.form_submit_button("Create account")
+
+if submitted:
+    if not username.strip() or not password:
+        st.warning("Please enter a username and password.")
+        st.stop()
+
+    try:
+        token, user = api_signup(username.strip(), password)
+    except Exception as e:
+        st.error(f"Signup failed: {e}")
+    else:
+        st.session_state["token"] = token
+        st.session_state["user"] = user
+        st.success("Account created. You're now signed in.")
+

--- a/frontend/services/auth_service.py
+++ b/frontend/services/auth_service.py
@@ -1,13 +1,67 @@
-#we can set mock to false when we have the real users
-USE_MOCK = True
+import os
+from typing import Any, Optional, Tuple
 
-def login(username, password):
-    if USE_MOCK:
-        mock_users = {"student1": "pass123", "athlete1": "pass456"}
-        return mock_users.get(username) == password
-    # TODO: POST /auth/login
+import requests
 
-def get_current_user():
-    if USE_MOCK:
-        return {"id": "u1", "name": "Alex", "role": "student", "mana": 7}
-    # TODO: GET /users/me
+
+BACKEND_URL = os.getenv("BACKEND_URL", "http://localhost:8000").rstrip("/")
+
+
+def _auth_headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _extract_token_and_user(payload: dict[str, Any]) -> Tuple[Optional[str], Optional[dict[str, Any]]]:
+    token = payload.get("access_token") or payload.get("jwt_token") or payload.get("token")
+    user = payload.get("user") or payload.get("current_user")
+    return token, user
+
+
+def signup(username: str, password: str) -> tuple[str, dict[str, Any]]:
+    """
+    Calls backend POST `/authentication/signup`.
+    Returns `(token, user)`.
+    """
+    url = f"{BACKEND_URL}/authentication/signup"
+    resp = requests.post(url, json={"username": username, "password": password}, timeout=20)
+    try:
+        data = resp.json()
+    except Exception:
+        data = {"detail": resp.text}
+
+    if resp.status_code >= 400:
+        raise RuntimeError(data.get("detail") or "Signup failed")
+
+    token, user = _extract_token_and_user(data)
+    if not token:
+        raise RuntimeError("Signup succeeded but no token was returned by backend")
+    return token, user or {}
+
+
+def login(username: str, password: str) -> tuple[str, dict[str, Any]]:
+    """
+    Calls backend POST `/authentication/login`.
+    Returns `(token, user)`.
+    """
+    url = f"{BACKEND_URL}/authentication/login"
+    resp = requests.post(url, json={"username": username, "password": password}, timeout=20)
+    try:
+        data = resp.json()
+    except Exception:
+        data = {"detail": resp.text}
+
+    if resp.status_code >= 400:
+        raise RuntimeError(data.get("detail") or "Login failed")
+
+    token, user = _extract_token_and_user(data)
+    if not token:
+        raise RuntimeError("Login succeeded but no token was returned by backend")
+    return token, user or {}
+
+
+def get_backend_url() -> str:
+    return BACKEND_URL
+
+
+def build_auth_headers(token: str) -> dict[str, str]:
+    return _auth_headers(token)

--- a/frontend/services/event_service.py
+++ b/frontend/services/event_service.py
@@ -1,0 +1,21 @@
+import requests
+
+from services.auth_service import BACKEND_URL, build_auth_headers
+
+
+def add_event(token: str, payload: dict) -> dict:
+    """
+    Creates a scheduled task/event via backend POST `/tasks/create`.
+    Payload is expected to align with backend's CreateTask model.
+    """
+    url = f"{BACKEND_URL}/tasks/create"
+    resp = requests.post(url, json=payload, headers=build_auth_headers(token), timeout=20)
+    try:
+        data = resp.json()
+    except Exception:
+        data = {"detail": resp.text}
+
+    if resp.status_code >= 400:
+        raise RuntimeError(data.get("detail") or "Failed to add event")
+    return data
+

--- a/frontend/services/mana_service.py
+++ b/frontend/services/mana_service.py
@@ -1,0 +1,25 @@
+import requests
+
+from services.auth_service import BACKEND_URL, build_auth_headers
+
+
+def log_energy(token: str, energy_level: float) -> dict:
+    """
+    Logs a mana/energy entry via backend POST `/energy/log`.
+    """
+    url = f"{BACKEND_URL}/energy/log"
+    resp = requests.post(
+        url,
+        json={"energy_level": float(energy_level)},
+        headers=build_auth_headers(token),
+        timeout=20,
+    )
+    try:
+        data = resp.json()
+    except Exception:
+        data = {"detail": resp.text}
+
+    if resp.status_code >= 400:
+        raise RuntimeError(data.get("detail") or "Failed to log energy")
+    return data
+


### PR DESCRIPTION
I updated the Streamlit frontend to use the backend API instead of the mock stuff.
Changes:

Signup + store the JWT token in session
Dashboard page now calls /dashboard/summary using the token
Log Mana/Energy page calls /energy/log
Updated Add Event page to use the logged-in token instead of a hardcoded user id
Added small frontend service helpers so the API calls are organized